### PR TITLE
Drkennetz zero point

### DIFF
--- a/challenges/2021-08-31-zero-point/solutions/python/drkennetz/README.md
+++ b/challenges/2021-08-31-zero-point/solutions/python/drkennetz/README.md
@@ -1,0 +1,37 @@
+# Zero Point
+
+Given a linked list, remove all consecutive nodes that sum to zero. 
+For example, suppose you are given the input `3 -> 4 -> -7 -> 5 -> -6 -> 6`. In this case, you should first remove `3 -> 4 -> -7`, then `-6 -> 6`, leaving only `5`.
+
+## Business Rules/Errata
+
+- ***Data Structure Required: Linked List***
+- Your input will be a linked list, where each node represents either a positive or negative integer.
+- Your return value should be in the form of a linked list containing only nodes that are not part of a consecutive sequence that sums to zero.
+- If your input linked list does not contain any nodes that qualify to be returned (such as `1 -> -1`), return `NULL` (or your language's equivalent).
+- Your input will contain at least one node with a value.
+
+## Examples
+
+```
+input = 1 -> 2 -> 3 -> 4 -> -4 -> -3 -> 5
+remove_zero_sequences(input)  // 1 -> 2 -> 5
+
+input = 2 -> -2 -> 3 -> 4 -> 5 -> -9
+remove_zero_sequences(input)  // 3
+
+input = 1 -> -10 -> 5 -> 4
+remove_zero_sequences(input)  // NULL
+```
+## Tackling This Challenge
+
+1. Make sure you've got the required software on your machine: python 3.7+
+2. If you haven't already, fork the CodingDojo repository ([INSTRUCTIONS](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo)).
+3. Navigate to this directory and run `npm install` to initialize the project.
+4. The challenge will be live-coded in our weekly Tusday meetup in the `solution.js` file.
+5. Run the tests to check your solution by navigating to this directory and running `./run-tests`.
+6. The results of the live coding demo will be added to the GitHub repository as a mob solution. Please feel free to tackle this challenge in your own way/language and submit your solution to the repo using [this solutions guide in our wiki](https://github.com/codeconnector/CodingDojo/wiki#solutions).
+
+## Requirements
+
+- python 3.7+

--- a/challenges/2021-08-31-zero-point/solutions/python/drkennetz/test/test_zeropoint.py
+++ b/challenges/2021-08-31-zero-point/solutions/python/drkennetz/test/test_zeropoint.py
@@ -10,20 +10,23 @@ class TestZeroPoint(unittest.TestCase):
         self.expected = [[1, 3], [5], [1, 1], [1, 2, 5], [2, 3], [-2, 3], [None], [5]]
 
     def test_zeropoint(self):
-        total_spaces = 30
+        total_spaces = 100
+        s = len("Input:")
         a = len("Actual:")
         e = len("Expected:")
-        pad = total_spaces - a - e
-        print("Actual:", " "*pad, "Expected:")
+        pad = (total_spaces - a - e - s)//2
+        print("Input:", " "*pad, "Actual:", " "*pad, "Expected:")
         for test, result in zip(self.tests, self.expected):
+            x = LinkedList.construct_dll_from_list(test)
             dll, exp = LinkedList.construct_dll_from_list(test), LinkedList.construct_dll_from_list(result)
             zerod = zeropoint.remove_zero_sequences_inplace(dll)
             act = zerod.print_list()
             expected = exp.print_list()
+            d = len(x.print_list())
             a = len(act)
             e = len(expected)
-            pad = total_spaces - a - e
-            print(act, " "*pad, expected)
+            pad = (total_spaces - a - e - d)//2
+            print(x.print_list(), " "*pad, act, " "*pad, expected)
             
                   
 

--- a/challenges/2021-08-31-zero-point/solutions/python/drkennetz/test/test_zeropoint.py
+++ b/challenges/2021-08-31-zero-point/solutions/python/drkennetz/test/test_zeropoint.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import unittest
+from zeropoint import LinkedList, zeropoint
+
+class TestZeroPoint(unittest.TestCase):
+    def setUp(self):
+        self.tests = [[1, 2, -2, 3], [3, 4, -7, 5, -6, 6], [1, 0, 1], [1, 2, 3, 4, -4, -3, 5],
+                      [2, 3, 4, 5, -9], [1, -1, -2, 3], [1, -10, 5, 4], [5]]
+        self.expected = [[1, 3], [5], [1, 1], [1, 2, 5], [2, 3], [-2, 3], [None], [5]]
+
+    def test_zeropoint(self):
+        total_spaces = 30
+        a = len("Actual:")
+        e = len("Expected:")
+        pad = total_spaces - a - e
+        print("Actual:", " "*pad, "Expected:")
+        for test, result in zip(self.tests, self.expected):
+            dll, exp = LinkedList.construct_dll_from_list(test), LinkedList.construct_dll_from_list(result)
+            zerod = zeropoint.remove_zero_sequences_inplace(dll)
+            act = zerod.print_list()
+            expected = exp.print_list()
+            a = len(act)
+            e = len(expected)
+            pad = total_spaces - a - e
+            print(act, " "*pad, expected)
+            
+                  
+
+    def tearDown(self):
+        pass
+
+if __name__ == "__main__":
+    unittest.main()

--- a/challenges/2021-08-31-zero-point/solutions/python/drkennetz/zeropoint/LinkedList.py
+++ b/challenges/2021-08-31-zero-point/solutions/python/drkennetz/zeropoint/LinkedList.py
@@ -1,0 +1,87 @@
+class Node:
+    def __init__(self, value):
+        self.value = value
+        self.prev = None
+        self.next = None
+
+class DoublyLinkedList:
+    def __init__(self):
+        self.head = None
+        self.tail = None
+        
+    def set_head(self, node):
+        if self.head is None:
+            self.head = node
+            self.tail = node
+            return
+        self.insert_before(self.head, node)
+
+    def set_tail(self, node):
+        if self.tail is None:
+            self.set_head(node)
+        self.insert_after(self.tail, node)
+
+    def insert_before(self, node, node_to_insert):
+        # no op case
+        if node_to_insert == self.head and node_to_insert == self.tail:
+            return
+        self.remove(node_to_insert)
+        node_to_insert.prev = node.prev
+        node_to_insert.next = node
+        if node.prev is None:
+            self.head = node_to_insert
+        else:
+            node.prev.next = node_to_insert
+        node.prev = node_to_insert
+
+    def insert_after(self, node, node_to_insert):
+        if node_to_insert == self.head and node_to_insert == self.tail:
+            return
+        self.remove(node_to_insert)
+        node_to_insert.prev = node
+        node_to_insert.next = node.next
+        if node.next is None:
+            self.tail = node_to_insert
+        else:
+            node.next.prev = node_to_insert
+        node.next = node_to_insert
+
+    def remove(self, node):
+        if node == self.head:
+            self.head = self.head.next
+        if node == self.tail:
+            self.tail = self.tail.prev
+        self.remove_node_bindings(node)
+
+    def remove_node_bindings(self, node):
+        if node.prev is not None:
+            node.prev.next = node.next
+        if node.next is not None:
+            node.next.prev = node.prev
+        node.prev = None
+        node.next = None
+
+    def print_list(self):
+        current = self.head
+        output = ""
+        while(current):
+            output += str(current.value)
+            output += " -> "
+            #print(current.value, " -> ",  end='')
+            current = current.next
+        #print('\n')
+        return output
+
+def construct_dll_from_list(array):
+    head = Node(array[0])
+    dll = DoublyLinkedList()
+    dll.set_head(head)
+    i = 1
+    current = dll.head
+    while i < len(array):
+        new_node = Node(array[i])
+        dll.insert_after(current, new_node)
+        current = current.next
+        i += 1
+    return dll
+            

--- a/challenges/2021-08-31-zero-point/solutions/python/drkennetz/zeropoint/zeropoint.py
+++ b/challenges/2021-08-31-zero-point/solutions/python/drkennetz/zeropoint/zeropoint.py
@@ -1,0 +1,41 @@
+def remove_zero_sequences_inplace(doubly_linked_list):
+    start = doubly_linked_list.head
+    current = doubly_linked_list.head.next
+
+    while start is not None:
+        
+        running_sum = start.value
+        
+        if start.value == 0:
+            # we don't need to add this or even keep track of it, we just need to remove it
+            start = start.next
+            doubly_linked_list.remove(start.prev)
+            
+        iterations_to_remove = 1
+        if start.next is not None:
+            current = start.next
+        else:
+            break
+        while current is not None:
+            running_sum += current.value
+            iterations_to_remove += 1
+            if running_sum == 0:
+                if current.next is not None:
+                    while iterations_to_remove:
+                        start = start.next
+                        doubly_linked_list.remove(start.prev)
+                        iterations_to_remove -= 1
+                else:
+                    while iterations_to_remove:
+                        if start.next is not None:
+                            start = start.next
+                            doubly_linked_list.remove(start.prev)
+                            iterations_to_remove -= 1
+                        else: # is tail
+                            doubly_linked_list.remove(start)
+                            iterations_to_remove -= 1
+            current = current.next
+
+        start = start.next
+        
+    return doubly_linked_list


### PR DESCRIPTION
This solution modifies the original linked list in place, rather than creating a second object. Technically, my tests aren't tests but I wanted to provide a visual representation rather than a comparison. Technically one fails but it's still pretty cool:

```
[dkennetz@nodecn201 prod test]$ python3 test_zeropoint.py
Input:                                         Actual:                                         Expected:
1 -> 2 -> -2 -> 3 ->                                1 -> 3 ->                                1 -> 3 ->
3 -> 4 -> -7 -> 5 -> -6 -> 6 ->                                5 ->                                5 ->
1 -> 0 -> 1 ->                                   1 -> 1 ->                                   1 -> 1 ->
1 -> 2 -> 3 -> 4 -> -4 -> -3 -> 5 ->                   1 -> 2 -> 5 ->                   1 -> 2 -> 5 ->
2 -> 3 -> 4 -> 5 -> -9 ->                              2 -> 3 ->                              2 -> 3 ->
1 -> -1 -> -2 -> 3 ->                               -2 -> 3 ->                               -2 -> 3 ->
1 -> -10 -> 5 -> 4 ->                                                                           None ->
5 ->                                             5 ->                                             5 ->
```
