### PR TITLE
2021 09 14 drkennetz

### DIFF
--- a/challenges/2021-09-14-fast-peak-picker/solutions/go/drkennetz/drkennetz.go
+++ b/challenges/2021-09-14-fast-peak-picker/solutions/go/drkennetz/drkennetz.go
@@ -1,0 +1,39 @@
+package drkennetz
+
+// FastPeakPicker implements a binary search to find the peak value in the array
+func FastPeakPicker(peaks []int) int {
+	lower := 0
+	upper := len(peaks)-1
+	for lower <= upper {
+		middle := lower + (upper - lower)/2
+		if middle == 0 || middle == len(peaks) - 1 {
+			// we've hit the upper or lower bound
+			return peaks[middle]
+		}
+		if peaks[middle] > peaks[middle - 1] && peaks[middle] > peaks[middle + 1] {
+			// we found the value we're looking for
+			return peaks[middle]
+		} else if peaks[middle] > peaks[middle - 1] {
+			// we want to use the right half
+			lower = middle + 1
+		} else {
+			// we want to use the left halfis
+			upper = middle - 1
+		}
+	}
+
+	return -1
+}
+
+// LinearFastPeakPicker implements a linear search to find the peak value in the array
+func LinearFastPeakPicker(peaks []int) int {
+	upper := len(peaks) - 1
+	for i := 0; i < len(peaks); i++ {
+		if i == upper {
+			return peaks[i]
+		} else if peaks[i] > peaks[i+1] {
+			return peaks[i]
+		}
+	}
+	return -1
+}

--- a/challenges/2021-09-14-fast-peak-picker/solutions/go/drkennetz/drkennetz_test.go
+++ b/challenges/2021-09-14-fast-peak-picker/solutions/go/drkennetz/drkennetz_test.go
@@ -1,0 +1,133 @@
+package drkennetz
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestFastPeakPicker(t *testing.T) {
+	tables := []struct{
+		input []int
+		result int
+	} {
+		{[]int{1, 2, 3, 2, 1}, 3},
+		{[]int{1, 2, 3, 4, 5}, 5},
+		{[]int{5, 4, 3, 2, 1}, 5},
+		{[]int{1}, 1},
+	}
+	for _, table := range tables {
+		actual := FastPeakPicker(table.input)
+		if actual != table.result {
+			fmt.Println("FAIL, expected: ", table.result, "got: ", actual)
+		} else {
+			fmt.Println("SUCCESS!")
+		}
+	}
+}
+
+func TestLinearFastPeakPicker(t *testing.T) {
+	tables := []struct{
+		input []int
+		result int
+	} {
+		{[]int{1, 2, 3, 2, 1}, 3},
+		{[]int{1, 2, 3, 4, 5}, 5},
+		{[]int{5, 4, 3, 2, 1}, 5},
+		{[]int{1}, 1},
+	}
+	for _, table := range tables {
+		actual := LinearFastPeakPicker(table.input)
+		if actual != table.result {
+			fmt.Println("FAIL, expected: ", table.result, "got: ", actual)
+		} else {
+			fmt.Println("SUCCESS!")
+		}
+	}
+}
+
+func BenchmarkFastPeakPicker1(b *testing.B) {
+	rand.Seed(time.Now().Unix())
+	input := rand.Perm(10000)
+	input = append(input, math.MaxInt32)
+	sort.Ints(input)
+	input2 := rand.Perm(100000)
+	sort.Ints(input2)
+	input = append(input, input2...)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		FastPeakPicker(input)
+	}
+}
+
+func BenchmarkLinearFastPeakPicker1(b *testing.B) {
+	rand.Seed(time.Now().Unix())
+	input := rand.Perm(10000)
+	input = append(input, math.MaxInt32)
+	sort.Ints(input)
+	input2 := rand.Perm(100000)
+	sort.Ints(input2)
+	input = append(input, input2...)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		LinearFastPeakPicker(input)
+	}
+}
+func BenchmarkFastPeakPicker2(b *testing.B) {
+	rand.Seed(time.Now().Unix())
+	input := rand.Perm(55000)
+	input = append(input, math.MaxInt32)
+	sort.Ints(input)
+	input2 := rand.Perm(55000)
+	sort.Ints(input2)
+	input = append(input, input2...)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		FastPeakPicker(input)
+	}
+}
+
+func BenchmarkLinearFastPeakPicker2(b *testing.B) {
+	rand.Seed(time.Now().Unix())
+	input := rand.Perm(55000)
+	input = append(input, math.MaxInt32)
+	sort.Ints(input)
+	input2 := rand.Perm(55000)
+	sort.Ints(input2)
+	input = append(input, input2...)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		LinearFastPeakPicker(input)
+	}
+}
+
+func BenchmarkFastPeakPicker3(b *testing.B) {
+	rand.Seed(time.Now().Unix())
+	input := rand.Perm(100000)
+	input = append(input, math.MaxInt32)
+	sort.Ints(input)
+	input2 := rand.Perm(10000)
+	sort.Ints(input2)
+	input = append(input, input2...)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		FastPeakPicker(input)
+	}
+}
+
+func BenchmarkLinearFastPeakPicker3(b *testing.B) {
+	rand.Seed(time.Now().Unix())
+	input := rand.Perm(100000)
+	input = append(input, math.MaxInt32)
+	sort.Ints(input)
+	input2 := rand.Perm(10000)
+	sort.Ints(input2)
+	input = append(input, input2...)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		LinearFastPeakPicker(input)
+	}
+}

--- a/challenges/2021-09-14-fast-peak-picker/solutions/go/drkennetz/go.mod
+++ b/challenges/2021-09-14-fast-peak-picker/solutions/go/drkennetz/go.mod
@@ -1,0 +1,3 @@
+module drkennetz
+
+go 1.15


### PR DESCRIPTION
Three benchmark cases:
1. Largest int was near the beginning of the array
2. Largest int was in the middle of the array
3. Largest int was near the end of the array

We can see here clearly that the linear solution scales linearly, while the binary search scales logarithmically. Very cool!
```
C:\Users\dkennetz\fun\CodingDojo\challenges\2021-09-14-fast-peak-picker\solutions\go\drkennetz>go test --bench=. -benchtime=200000x
SUCCESS!
SUCCESS!
SUCCESS!
SUCCESS!
SUCCESS!
SUCCESS!
SUCCESS!
SUCCESS!
goos: windows
goarch: amd64
BenchmarkFastPeakPicker1-6                200000                49.8 ns/op
BenchmarkLinearFastPeakPicker1-6          200000              6895 ns/op
BenchmarkFastPeakPicker2-6                200000                 5.00 ns/op
BenchmarkLinearFastPeakPicker2-6          200000             38108 ns/op
BenchmarkFastPeakPicker3-6                200000                54.8 ns/op
BenchmarkLinearFastPeakPicker3-6          200000             72757 ns/op
PASS
ok      _/C_/Users/dkennetz/fun/CodingDojo/challenges/2021-09-14-fast-peak-picker/solutions/go/drkennetz        24.518s
```