### PR TITLE
Create .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+test-it.sh linguist-detectable=false
+run-tests.sh linguist-detectable=false
+run-tests linguist-detectable=false
+*-test-runner.sh linguist-detectable=false


### PR DESCRIPTION
This _should_ remove the test runner shell scripts from the language list shown on the main GitHub page, without removing the bash solutions (there are a couple). Adds a `.gitattributes` file with instructions to ignore any of the test runner scripts.

Closes #199 